### PR TITLE
Updating Makefile to work on first run

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,3 @@
 build:
-	rm addon.zip
+	rm -f addon.zip
 	zip -r addon.zip * -x Makefile README.md


### PR DESCRIPTION
If no addon.zip is found, rm will throw an error. This can be fixed using the '-f' parameter.